### PR TITLE
Add support for custom Prometheus labels

### DIFF
--- a/M5StickCPlus.ino
+++ b/M5StickCPlus.ino
@@ -48,20 +48,20 @@ PromLokiTransport transport;
 PromClient client(transport);
 
 // Create a write request for 11 time series.
-WriteRequest req(11, 1024);
+WriteRequest req(11, 2048);
 
 // Define all our timeseries
-TimeSeries ts_m5stick_temperature(1, "m5stick_temp", "");
-TimeSeries ts_m5stick_humidity(1, "m5stick_hum", "");
-TimeSeries ts_m5stick_pressure(1, "m5stick_pressure", "");
-TimeSeries ts_m5stick_Iusb(1, "m5stick_Iusb", "");
-TimeSeries ts_m5stick_disCharge(1, "m5stick_disCharge", "");
-TimeSeries ts_m5stick_Iin(1, "m5stick_Iin", "");
-TimeSeries ts_m5stick_BatTemp(1, "m5stick_BatTemp", "");
-TimeSeries ts_m5stick_Vaps(1, "m5stick_Vaps", "");
-TimeSeries ts_m5stick_bat(1, "m5stick_bat", "");
-TimeSeries ts_m5stick_charge(1, "m5stick_charge", "");
-TimeSeries ts_m5stick_vbat(1, "m5stick_vbat", "");
+TimeSeries ts_m5stick_temperature(1, "m5stick_temp", PROM_LABELS);
+TimeSeries ts_m5stick_humidity(1, "m5stick_hum", PROM_LABELS);
+TimeSeries ts_m5stick_pressure(1, "m5stick_pressure", PROM_LABELS);
+TimeSeries ts_m5stick_Iusb(1, "m5stick_Iusb", PROM_LABELS);
+TimeSeries ts_m5stick_disCharge(1, "m5stick_disCharge", PROM_LABELS);
+TimeSeries ts_m5stick_Iin(1, "m5stick_Iin", PROM_LABELS);
+TimeSeries ts_m5stick_BatTemp(1, "m5stick_BatTemp", PROM_LABELS);
+TimeSeries ts_m5stick_Vaps(1, "m5stick_Vaps", PROM_LABELS);
+TimeSeries ts_m5stick_bat(1, "m5stick_bat", PROM_LABELS);
+TimeSeries ts_m5stick_charge(1, "m5stick_charge", PROM_LABELS);
+TimeSeries ts_m5stick_vbat(1, "m5stick_vbat", PROM_LABELS);
 
 
 // ===================================================

--- a/config.h
+++ b/config.h
@@ -12,6 +12,12 @@
 #define GC_USER ""
 #define GC_PASS ""
 
+// Comma-separated Prometheus labels (key=value) to apply to the metrics from the sensor
+// Example: site=home,location=balcony
+//
+// Adding labels might require you to increase the size of the WriteRequest buffer in M5StickCPlus.ino
+#define PROM_LABELS ""
+
 // Set to 1 to show debug information on the LCD screen, or 0 to not display
 // The debug information will show if you are able to connect to the WiFi or not, and whether writing the metrics to Prometheus was successful or not
 #define LCD_SHOW_DEBUG_INFO "1"


### PR DESCRIPTION
1. Added PROM_LABELS to `config.h` and pass it to the third argument in the constructor for TimeSeries to support user defined label sets, making this base a little bit more useful for users that have multiple controllers, and providing an entrypoint for a deep-dive in the DIY IOT intro.
2. Increased the buffer for `req`, I ran into problems almost immediately with a 1024 buffer and 2048 worked just fine for me.