### PR TITLE
Initialize the temp sensor to prevent it from crashing

### DIFF
--- a/M5StickCPlus.ino
+++ b/M5StickCPlus.ino
@@ -85,6 +85,7 @@ void setup() {
     
     Wire.begin(32, 33);       // Wire init, adding the I2C bus.  
     qmp6988.init();           // Initiallize the pressure sensor    
+    sht30.init();             // Initialize the temperature sensor
 
     // Configure and start the transport/WiFi layer
     Disbuff.setCursor(10, 30);


### PR DESCRIPTION
The device was crashing with the following error:
```
14:22:08.202 -> Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.
14:22:08.202 -> 
14:22:08.202 -> Core  1 register dump:
14:22:08.202 -> PC      : 0x400d7253  PS      : 0x00060d30  A0      : 0x800d73d7  A1      : 0x3ffb2700  
14:22:08.235 -> A2      : 0x00000000  A3      : 0x00000000  A4      : 0x0000e8d2  A5      : 0x00000000  
14:22:08.235 -> A6      : 0xadb333d8  A7      : 0x328974c8  A8      : 0xfffe0000  A9      : 0x00000000  
14:22:08.235 -> A10     : 0xe8d20000  A11     : 0x000099f0  A12     : 0x86920000  A13     : 0xb58b0000  
14:22:08.235 -> A14     : 0x00000000  A15     : 0x00000000  SAR     : 0x0000000f  EXCCAUSE: 0x0000001c  
14:22:08.269 -> EXCVADDR: 0x00000040  LBEG    : 0x400895fc  LEND    : 0x40089612  LCOUNT  : 0xffffffff  
14:22:08.269 -> 
14:22:08.269 -> 
14:22:08.269 -> Backtrace: 0x400d7250:0x3ffb2700 0x400d73d4:0x3ffb2720 0x400d8954:0x3ffb2740 0x400d2af5:0x3ffb2790 0x400edd01:0x3ffb2820
14:22:08.269 -> 
14:22:08.269 -> 
14:22:08.269 -> 
14:22:08.269 -> 
14:22:08.269 -> ELF file SHA256: 943ce1bc0631683a
```

The reason for that was that the SHT30 sensor wasn't initialized properly which caused sht30.get() to freak out. 

This PR addresses this issue and adds init code.